### PR TITLE
Премахване на ненужна информация за авторско право от долната част на сайта

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -348,9 +348,7 @@
                 </div>
                 <div class="copiright text-center col-xs-12">
                     <div class="row">
-                        <strong>Copyright &copy; 2018 </strong>
-                        {{ __('custom.by') }}
-                        <a target="_blank" href="http://data.egov.bg/"> {{ __('custom.copyright') }}</a>
+                        {{ __('custom.copyright') }}
                     </div>
                 </div>
             </footer>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1153188/52878792-2e04c300-3166-11e9-960f-60d4c7b721d1.png)

Информацията за авторско право в долната част на сайта е с неправилна година и в контекста на българското законодателство и функцията на Портала в най-добрия случай е ненужна, ако не грешна и объркваща.

Тази заявка опростява долната част на сайта като оставя само заглавието на Портала.